### PR TITLE
Add migrations

### DIFF
--- a/db/migrate/20240117090622_create_users.rb
+++ b/db/migrate/20240117090622_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string    :username
+      t.string    :password_digest
+      t.string    :fb_useraccount_id
+      t.string    :fb_access_token
+      t.timestamps
+
+      t.index :username, unique: true
+    end
+  end
+end

--- a/db/migrate/20240122063518_create_ad_accounts.rb
+++ b/db/migrate/20240122063518_create_ad_accounts.rb
@@ -1,0 +1,31 @@
+class CreateAdAccounts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ad_accounts, :id => false, primary_key: :ad_account_id do |t|
+      t.string        :ad_account_id, null: false
+      t.string        :ad_account_name
+      t.string        :ad_account_currency
+      t.datetime      :stop_date
+      t.belongs_to    :users
+      t.timestamps
+
+      t.index :ad_account_id, unique: true
+    end
+
+    create_table :ad_accounts_metrics do |t|
+      t.integer     :clicks
+      t.float       :ctr
+      t.integer     :link_clicks
+      t.float       :linl_clicks_ctr
+      t.float       :cost_per_link_clicks
+      t.integer     :comments
+      t.integer     :impressions
+      t.integer     :likes
+      t.float       :spend
+      t.datetime    :event_date, null: false
+      t.string      :ad_account_id, null: false
+      t.timestamps
+
+      t.index [:ad_account_id, :event_date], unique: true
+    end
+  end
+end

--- a/db/migrate/20240122064113_create_ad_campaigns.rb
+++ b/db/migrate/20240122064113_create_ad_campaigns.rb
@@ -1,0 +1,35 @@
+class CreateAdCampaigns < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ad_campaigns, :id => false, primary_key: :ad_campaign_id do |t| 
+      t.string        :ad_campaign_id, null: false
+      t.string        :ad_campaign_name
+      t.string        :ad_campaign_objective
+      t.datetime      :ad_campaign_startdate
+      t.integer       :ad_campaign_lifetime_budget
+      t.string        :ad_campaign_budgeting_type
+      t.string        :ad_account_id, null: false
+      t.timestamps
+
+      t.index [:ad_campaign_id,:ad_account_id], unique:true
+    end
+
+    create_table :ad_campaigns_metrics do |t|
+      t.integer     :clicks
+      t.float       :ctr
+      t.integer     :link_clicks
+      t.float       :linl_clicks_ctr
+      t.float       :cost_per_link_clicks
+      t.integer     :comments
+      t.integer     :impressions
+      t.integer     :likes
+      t.float       :spend
+      t.datetime    :event_date, null: false
+      t.string      :ad_campaign_id, null: false
+      t.string      :ad_account_id, null: false
+      t.timestamps
+
+      t.index [:ad_campaign_id, :event_date], unique: true
+      t.index [:ad_account_id, :event_date]
+    end
+  end
+end

--- a/db/migrate/20240122064113_create_ad_campaigns.rb
+++ b/db/migrate/20240122064113_create_ad_campaigns.rb
@@ -10,7 +10,7 @@ class CreateAdCampaigns < ActiveRecord::Migration[7.1]
       t.string        :ad_account_id, null: false
       t.timestamps
 
-      t.index [:ad_campaign_id,:ad_account_id], unique:true
+      t.index [:ad_account_id,:ad_campaign_id], unique:true
     end
 
     create_table :ad_campaigns_metrics do |t|

--- a/db/migrate/20240122064122_create_ad_sets.rb
+++ b/db/migrate/20240122064122_create_ad_sets.rb
@@ -1,0 +1,38 @@
+class CreateAdSets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ad_sets, :id => false, primary_key: :ad_set_id do |t| 
+      t.string          :ad_set_id, null:false
+      t.string          :ad_set_name
+      t.string          :ad_set_goal
+      t.datetime        :ad_set_start_date
+      t.integer         :ad_set_daily_budget
+      t.integer         :ad_set_lifetime_budget
+      t.string          :ad_set_billing_event
+      t.string          :ad_campaign_id, null:false
+      t.string          :ad_account_id, null:false
+      t.timestamps
+
+      t.index :ad_set_id, unique: true
+      t.index [:ad_campaign_id, :ad_account_id] 
+    end
+
+    create_table :ad_sets_metrics do |t|
+      t.integer     :clicks
+      t.float       :ctr
+      t.integer     :link_clicks
+      t.float       :linl_clicks_ctr
+      t.float       :cost_per_link_clicks
+      t.integer     :comments
+      t.integer     :impressions
+      t.integer     :likes
+      t.float       :spend
+      t.datetime    :event_date, null: false
+      t.string      :ad_set_id, null: false
+      t.string      :ad_account_id, null: false
+      t.timestamps
+
+      t.index [:ad_set_id, :event_date], unique: true
+      t.index [:ad_account_id, :event_date]
+    end
+  end
+end

--- a/db/migrate/20240122064122_create_ad_sets.rb
+++ b/db/migrate/20240122064122_create_ad_sets.rb
@@ -13,7 +13,7 @@ class CreateAdSets < ActiveRecord::Migration[7.1]
       t.timestamps
 
       t.index :ad_set_id, unique: true
-      t.index [:ad_campaign_id, :ad_account_id] 
+      t.index [:ad_account_id, :ad_campaign_id] 
     end
 
     create_table :ad_sets_metrics do |t|

--- a/db/migrate/20240122064126_create_ads.rb
+++ b/db/migrate/20240122064126_create_ads.rb
@@ -1,0 +1,36 @@
+class CreateAds < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ads, :id => false, primary_key: :ad_id do |t|
+      t.string          :ad_id, null: false
+      t.string          :ad_name
+      t.string          :ad_type
+      t.string          :ad_format
+      t.datetime        :ad_start_date
+      t.string          :ad_set_id, null: false
+      t.string          :ad_account_id, null: false
+      t.timestamps
+
+      t.index :ad_id, unique: true
+      t.index [:ad_set_id, :ad_account_id]
+    end
+
+    create_table :ads_metrics do |t|
+      t.integer     :clicks
+      t.float       :ctr
+      t.integer     :link_clicks
+      t.float       :linl_clicks_ctr
+      t.float       :cost_per_link_clicks
+      t.integer     :comments
+      t.integer     :impressions
+      t.integer     :likes
+      t.float       :spend
+      t.datetime    :event_date, null: false
+      t.string      :ad_id, null: false
+      t.string      :ad_account_id, null: false
+      t.timestamps
+
+      t.index [:ad_id, :event_date], unique: true
+      t.index [:ad_account_id, :event_date]
+    end
+  end
+end

--- a/db/migrate/20240122064126_create_ads.rb
+++ b/db/migrate/20240122064126_create_ads.rb
@@ -11,7 +11,7 @@ class CreateAds < ActiveRecord::Migration[7.1]
       t.timestamps
 
       t.index :ad_id, unique: true
-      t.index [:ad_set_id, :ad_account_id]
+      t.index [:ad_account_id, :ad_set_id]
     end
 
     create_table :ads_metrics do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_22_064126) do
     t.string "ad_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ad_campaign_id", "ad_account_id"], name: "index_ad_campaigns_on_ad_campaign_id_and_ad_account_id", unique: true
+    t.index ["ad_account_id", "ad_campaign_id"], name: "index_ad_campaigns_on_ad_account_id_and_ad_campaign_id", unique: true
   end
 
   create_table "ad_campaigns_metrics", force: :cascade do |t|
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_22_064126) do
     t.string "ad_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ad_campaign_id", "ad_account_id"], name: "index_ad_sets_on_ad_campaign_id_and_ad_account_id"
+    t.index ["ad_account_id", "ad_campaign_id"], name: "index_ad_sets_on_ad_account_id_and_ad_campaign_id"
     t.index ["ad_set_id"], name: "index_ad_sets_on_ad_set_id", unique: true
   end
 
@@ -120,8 +120,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_22_064126) do
     t.string "ad_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["ad_account_id", "ad_set_id"], name: "index_ads_on_ad_account_id_and_ad_set_id"
     t.index ["ad_id"], name: "index_ads_on_ad_id", unique: true
-    t.index ["ad_set_id", "ad_account_id"], name: "index_ads_on_ad_set_id_and_ad_account_id"
   end
 
   create_table "ads_metrics", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,156 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_01_22_064126) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "ad_accounts", id: false, force: :cascade do |t|
+    t.string "ad_account_id", null: false
+    t.string "ad_account_name"
+    t.string "ad_account_currency"
+    t.datetime "stop_date"
+    t.bigint "users_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_account_id"], name: "index_ad_accounts_on_ad_account_id", unique: true
+    t.index ["users_id"], name: "index_ad_accounts_on_users_id"
+  end
+
+  create_table "ad_accounts_metrics", force: :cascade do |t|
+    t.integer "clicks"
+    t.float "ctr"
+    t.integer "link_clicks"
+    t.float "linl_clicks_ctr"
+    t.float "cost_per_link_clicks"
+    t.integer "comments"
+    t.integer "impressions"
+    t.integer "likes"
+    t.float "spend"
+    t.datetime "event_date", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_account_id", "event_date"], name: "index_ad_accounts_metrics_on_ad_account_id_and_event_date", unique: true
+  end
+
+  create_table "ad_campaigns", id: false, force: :cascade do |t|
+    t.string "ad_campaign_id", null: false
+    t.string "ad_campaign_name"
+    t.string "ad_campaign_objective"
+    t.datetime "ad_campaign_startdate"
+    t.integer "ad_campaign_lifetime_budget"
+    t.string "ad_campaign_budgeting_type"
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_campaign_id", "ad_account_id"], name: "index_ad_campaigns_on_ad_campaign_id_and_ad_account_id", unique: true
+  end
+
+  create_table "ad_campaigns_metrics", force: :cascade do |t|
+    t.integer "clicks"
+    t.float "ctr"
+    t.integer "link_clicks"
+    t.float "linl_clicks_ctr"
+    t.float "cost_per_link_clicks"
+    t.integer "comments"
+    t.integer "impressions"
+    t.integer "likes"
+    t.float "spend"
+    t.datetime "event_date", null: false
+    t.string "ad_campaign_id", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_account_id", "event_date"], name: "index_ad_campaigns_metrics_on_ad_account_id_and_event_date"
+    t.index ["ad_campaign_id", "event_date"], name: "index_ad_campaigns_metrics_on_ad_campaign_id_and_event_date", unique: true
+  end
+
+  create_table "ad_sets", id: false, force: :cascade do |t|
+    t.string "ad_set_id", null: false
+    t.string "ad_set_name"
+    t.string "ad_set_goal"
+    t.datetime "ad_set_start_date"
+    t.integer "ad_set_daily_budget"
+    t.integer "ad_set_lifetime_budget"
+    t.string "ad_set_billing_event"
+    t.string "ad_campaign_id", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_campaign_id", "ad_account_id"], name: "index_ad_sets_on_ad_campaign_id_and_ad_account_id"
+    t.index ["ad_set_id"], name: "index_ad_sets_on_ad_set_id", unique: true
+  end
+
+  create_table "ad_sets_metrics", force: :cascade do |t|
+    t.integer "clicks"
+    t.float "ctr"
+    t.integer "link_clicks"
+    t.float "linl_clicks_ctr"
+    t.float "cost_per_link_clicks"
+    t.integer "comments"
+    t.integer "impressions"
+    t.integer "likes"
+    t.float "spend"
+    t.datetime "event_date", null: false
+    t.string "ad_set_id", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_account_id", "event_date"], name: "index_ad_sets_metrics_on_ad_account_id_and_event_date"
+    t.index ["ad_set_id", "event_date"], name: "index_ad_sets_metrics_on_ad_set_id_and_event_date", unique: true
+  end
+
+  create_table "ads", id: false, force: :cascade do |t|
+    t.string "ad_id", null: false
+    t.string "ad_name"
+    t.string "ad_type"
+    t.string "ad_format"
+    t.datetime "ad_start_date"
+    t.string "ad_set_id", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_id"], name: "index_ads_on_ad_id", unique: true
+    t.index ["ad_set_id", "ad_account_id"], name: "index_ads_on_ad_set_id_and_ad_account_id"
+  end
+
+  create_table "ads_metrics", force: :cascade do |t|
+    t.integer "clicks"
+    t.float "ctr"
+    t.integer "link_clicks"
+    t.float "linl_clicks_ctr"
+    t.float "cost_per_link_clicks"
+    t.integer "comments"
+    t.integer "impressions"
+    t.integer "likes"
+    t.float "spend"
+    t.datetime "event_date", null: false
+    t.string "ad_id", null: false
+    t.string "ad_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ad_account_id", "event_date"], name: "index_ads_metrics_on_ad_account_id_and_event_date"
+    t.index ["ad_id", "event_date"], name: "index_ads_metrics_on_ad_id_and_event_date", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username"
+    t.string "password_digest"
+    t.string "fb_useraccount_id"
+    t.string "fb_access_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
+end


### PR DESCRIPTION
Summary : Created schema for storing the dimensions & metrics for Ads, AdSets, Campaigns & Account. Each of these has a corresponding metrics table. 

PK for each of the meta tables would be the ID returned by FB. Same PK is used for correlation with metrics tables. 

Metrics tables have auto-increment PK. Unique key on metdata_id + event_date (Ex : Ad_set_id + date). Additional Index on date + account_id. 